### PR TITLE
Fix recursive call to constructor

### DIFF
--- a/Text/Wiki.php
+++ b/Text/Wiki.php
@@ -417,7 +417,7 @@ class Text_Wiki {
     */
     function Text_Wiki($rules = null)
     {
-        $this->__construct($rules);
+        self::__construct($rules);
     }
 
     /**

--- a/Text/Wiki/Parse.php
+++ b/Text/Wiki/Parse.php
@@ -145,7 +145,7 @@ class Text_Wiki_Parse {
 
     function Text_Wiki_Parse(&$obj)
     {
-        $this->__construct($obj);
+        self::__construct($obj);
     }
 
 

--- a/Text/Wiki/Parse/Default/Delimiter.php
+++ b/Text/Wiki/Parse/Default/Delimiter.php
@@ -67,7 +67,7 @@ class Text_Wiki_Parse_Default_Delimiter extends Text_Wiki_Parse {
     
     function Text_Wiki_Parse_Default_Delimiter(&$obj)
     {
-        $this->__construct($obj);
+        self::__construct($obj);
     }
     
     

--- a/Text/Wiki/Parse/Default/Freelink.php
+++ b/Text/Wiki/Parse/Default/Freelink.php
@@ -96,7 +96,7 @@ class Text_Wiki_Parse_Default_Freelink extends Text_Wiki_Parse {
     
     function Text_Wiki_Parse_Default_Freelink(&$obj)
     {
-        $this->__construct($obj);
+        self::__construct($obj);
     }
     
     

--- a/Text/Wiki/Parse/Default/Image.php
+++ b/Text/Wiki/Parse/Default/Image.php
@@ -96,7 +96,7 @@ class Text_Wiki_Parse_Default_Image extends Text_Wiki_Parse {
      */
     function Text_Wiki_Parse_Default_Image(&$obj)
     {
-        $this->__construct($obj);
+        self::__construct($obj);
     }
 
     /**

--- a/Text/Wiki/Parse/Default/Smiley.php
+++ b/Text/Wiki/Parse/Default/Smiley.php
@@ -143,7 +143,7 @@ class Text_Wiki_Parse_Default_Smiley extends Text_Wiki_Parse {
      */
     function Text_Wiki_Parse_Default_Smiley(&$obj)
     {
-        $this->__construct($obj);
+        self::__construct($obj);
     }
 
     /**

--- a/Text/Wiki/Parse/Default/Url.php
+++ b/Text/Wiki/Parse/Default/Url.php
@@ -132,7 +132,7 @@ class Text_Wiki_Parse_Default_Url extends Text_Wiki_Parse {
     
     function Text_Wiki_Parse_Default_Url(&$obj)
     {
-        $this->__construct($obj);
+        self::__construct($obj);
     }
     
     

--- a/Text/Wiki/Parse/Default/Wikilink.php
+++ b/Text/Wiki/Parse/Default/Wikilink.php
@@ -117,7 +117,7 @@ class Text_Wiki_Parse_Default_Wikilink extends Text_Wiki_Parse {
 
     function Text_Wiki_Parse_Default_Wikilink(&$obj)
     {
-        $this->__construct($obj);
+        self::__construct($obj);
     }
 
 

--- a/Text/Wiki/Render.php
+++ b/Text/Wiki/Render.php
@@ -148,7 +148,7 @@ class Text_Wiki_Render {
 
     function Text_Wiki_Render(&$obj)
     {
-        $this->__construct($obj);
+        self::__construct($obj);
     }
 
 

--- a/Text/Wiki/Render/Docbook/Heading.php
+++ b/Text/Wiki/Render/Docbook/Heading.php
@@ -161,7 +161,7 @@ class Text_Wiki_Render_Docbook_Heading extends Text_Wiki_Render {
      */
     function Text_Wiki_Render_Docbook_Heading(&$obj)
     {
-        $this->__construct($obj);
+        self::__construct($obj);
     }
 
      /**


### PR DESCRIPTION
when a child class class to the old constructor in the parent.

Example: Text_Wiki_Mediawiki calls parent::Text_Wiki that calls $this->__constructor (in this
context is Text_Wiki_Mediawiki::__constructor), that calls parent::Text_Wiki again.