### PR TITLE
Adjust deprecated string offset access syntax with curly braces

### DIFF
--- a/Text/Wiki.php
+++ b/Text/Wiki.php
@@ -699,7 +699,7 @@ class Text_Wiki
         // the target name is not null, and not '', but does not exist
         // in the list of rules. this means we're trying to insert after
         // a target key, but the target key isn't there.
-        if (! is_null($tgt) && $tgt != '' 
+        if (! is_null($tgt) && $tgt != ''
             && ! in_array($tgt, $this->rules)
         ) {
             return false;
@@ -947,7 +947,7 @@ class Text_Wiki
             for ($i = 0; $i < $k; $i++) {
 
                 // the current character
-                $char = $this->source{$i};
+                $char = $this->source[$i];
 
                 // are alredy in a delimited section?
                 if ($in_delim) {
@@ -1182,7 +1182,7 @@ class Text_Wiki
      * @param int   $rule    The rule name to use.
      * @param array $options An associative array of options for the
      *                       token array element.  The keys and values are
-     *                       specific to the rule, and may or may not be common 
+     *                       specific to the rule, and may or may not be common
      *                       to other rule options.  Typical options keys are
      *                       'text' and 'type' but may include others.
      *

--- a/Text/Wiki/Parse/Default/Paragraph.php
+++ b/Text/Wiki/Parse/Default/Paragraph.php
@@ -1,52 +1,52 @@
 <?php
 
 /**
-* 
+*
 * Parses for paragraph blocks.
-* 
+*
 * @category Text
-* 
+*
 * @package Text_Wiki
-* 
+*
 * @author Paul M. Jones <pmjones@php.net>
-* 
+*
 * @license LGPL
-* 
+*
 * @version $Id$
-* 
+*
 */
 
 /**
-* 
+*
 * Parses for paragraph blocks.
-* 
+*
 * This class implements a Text_Wiki rule to find sections of the source
 * text that are paragraphs.  A para is any line not starting with a token
 * delimiter, followed by two newlines.
 *
 * @category Text
-* 
+*
 * @package Text_Wiki
-* 
+*
 * @author Paul M. Jones <pmjones@php.net>
-* 
+*
 */
 
 class Text_Wiki_Parse_Default_Paragraph extends Text_Wiki_Parse {
-    
+
     /**
-    * 
+    *
     * The regular expression used to find source text matching this
     * rule.
-    * 
+    *
     * @access public
-    * 
+    *
     * @var string
-    * 
+    *
     */
-    
+
     var $regex = "/^.*?\n\n/m";
-    
+
     var $conf = array(
         'skip' => array(
             'blockquote', // are we sure about this one?
@@ -59,16 +59,16 @@ class Text_Wiki_Parse_Default_Paragraph extends Text_Wiki_Parse {
             'toc'
         )
     );
-    
-    
+
+
     /**
-    * 
+    *
     * Generates a token entry for the matched text.  Token options are:
-    * 
+    *
     * 'start' => The starting point of the paragraph.
-    * 
+    *
     * 'end' => The ending point of the paragraph.
-    * 
+    *
     * @access public
     *
     * @param array &$matches The array of matches from parse().
@@ -77,23 +77,27 @@ class Text_Wiki_Parse_Default_Paragraph extends Text_Wiki_Parse {
     * the source text.
     *
     */
-    
+
     function process(&$matches)
     {
         $delim = $this->wiki->delim;
         $skip = $this->getConf('skip', array());
-        
+
         // was anything there?
         if (trim($matches[0]) == '') {
             return '';
         }
-        
+
         // does the match has tokens inside?
         preg_match_all("/(?:$delim)(\d+?)(?:$delim)/", $matches[0], $delimiters, PREG_SET_ORDER);
 
         // look each delimiter inside the match and see if it's skippable
         // (if we skip, it will not be marked as a paragraph)
         foreach ($delimiters as $d) {
+            if (!array_key_exists($d[1], $this->wiki->tokens)) {
+                continue;
+            }
+
             $token_type = strtolower($this->wiki->tokens[$d[1]][0]);
             if (in_array($token_type, $skip)) {
                 return $matches[0];
@@ -105,11 +109,11 @@ class Text_Wiki_Parse_Default_Paragraph extends Text_Wiki_Parse {
         $start = $this->wiki->addToken(
             $this->rule, array('type' => 'start')
         );
-        
+
         $end = $this->wiki->addToken(
             $this->rule, array('type' => 'end')
         );
-        
+
         return $start . trim($matches[0]) . $end;
     }
 }


### PR DESCRIPTION
This change fixes a deprecation warning in PHP 7.4