### PR TITLE
Fix composer2 warnings about version constraints and license identifier

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "include-path": [
         "./"
     ],
-    "license": "LGPL",
+    "license": "LGPL-2.1-or-later",
     "name": "pear/text_wiki",
     "support": {
         "issues": "http://pear.php.net/bugs/search.php?cmd=display&package_name[]=Text_Wiki",
@@ -33,7 +33,7 @@
     },
     "type": "library",
     "require": {
-        "pear/pear_exception": "*"
+        "pear/pear_exception": "^1"
     },
     "require-dev": {
         "phpunit/phpunit": "*"


### PR DESCRIPTION
Composer complains "LGPL" is not a valid license identifier anymore.
Analysis of links and remarks in pear website and source code provide ambiguity if it is strictly licensed as LGPL-2.1 or LGPL-2.1 and later as some links point to LGPL-3 while the code says 2.1.

Composer also complained about unbounded (*) version for PEAR_Exception. As only one major revision ever existed and no new one is likely to follow I decided to convert it to ^1 (Version 1 and all minor and bugfix versions inside it)